### PR TITLE
feat: add clipboard gist and external link to redirect a my repositories in github platform

### DIFF
--- a/app/[locale]/(app)/projects/page.tsx
+++ b/app/[locale]/(app)/projects/page.tsx
@@ -28,8 +28,6 @@ export default async function Page({ params: { locale } }: Props) {
   const repositories: GithubRepository[] = await getRepos();
   const gist = await getGist();
 
-  console.log(user);
-
   return (
     <PageWrapper>
       <Transmutation>

--- a/app/[locale]/(app)/projects/page.tsx
+++ b/app/[locale]/(app)/projects/page.tsx
@@ -1,7 +1,9 @@
 import { getGist, getProfile, getRepos } from "@/app/_services/github";
 import { GithubProfile, GithubRepository } from "@/interfaces/github";
+import { ExternalLink } from "@/packages/components/eternal-link";
 import { Separator } from "@/packages/components/ui/separator";
 import { Skeleton } from "@/packages/components/ui/skeleton";
+import { registry_github_static_info } from "@/registry/registry-github";
 import { ContentWrapper } from "@/ui/layout/content-wrapper";
 import { Heading } from "@/ui/layout/heading";
 import { PageWrapper } from "@/ui/layout/page-wrapper";
@@ -25,6 +27,8 @@ export default async function Page({ params: { locale } }: Props) {
   const user: GithubProfile = await getProfile();
   const repositories: GithubRepository[] = await getRepos();
   const gist = await getGist();
+
+  console.log(user);
 
   return (
     <PageWrapper>
@@ -56,9 +60,17 @@ export default async function Page({ params: { locale } }: Props) {
                 ))
                 .reverse()}
             </div>
-            <span className="mt-4 text-center text-xs text-muted-foreground">
-              {t("repositories_caption")}
-            </span>
+            <div className="mt-4 flex w-full items-center justify-between">
+              <span className="text-center text-xs text-muted-foreground">
+                {t("repositories_caption")}
+              </span>
+              <ExternalLink
+                href={registry_github_static_info.repositories_url}
+                className="text-xs"
+              >
+                {t("see_more")}
+              </ExternalLink>
+            </div>
           </div>
           <Separator className="mb-3.5 mt-2" />
           <div className="flex flex-col">

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,3 +1,4 @@
+import { Toaster } from "@/packages/components/ui/sonner";
 import { TooltipProvider } from "@/packages/components/ui/tooltip";
 import { ThemeProvider } from "@/providers/theme-provider";
 import "@/styles/globals.css";
@@ -15,6 +16,7 @@ export default async function Providers({
       disableTransitionOnChange
     >
       <TooltipProvider delayDuration={50}>{children}</TooltipProvider>
+      <Toaster />
     </ThemeProvider>
   );
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -16,7 +16,7 @@ export default async function Providers({
       disableTransitionOnChange
     >
       <TooltipProvider delayDuration={50}>{children}</TooltipProvider>
-      <Toaster />
+      <Toaster duration={3000} position="bottom-right" />
     </ThemeProvider>
   );
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "^18",
     "react-wrap-balancer": "^1.1.1",
     "sharp": "^0.33.5",
+    "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.2"

--- a/packages/components/ui/sonner.tsx
+++ b/packages/components/ui/sonner.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner } from "sonner"
+
+type ToasterProps = React.ComponentProps<typeof Sonner>
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
+      sonner:
+        specifier: ^1.5.0
+        version: 1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^2.5.2
         version: 2.5.2
@@ -2344,6 +2347,12 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  sonner@1.5.0:
+    resolution: {integrity: sha512-FBjhG/gnnbN6FY0jaNnqZOMmB73R+5IiyYAw8yBj7L54ER7HB3fOSE5OFiQiE2iXWxeXKvg6fIP4LtVppHEdJA==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4891,6 +4900,11 @@ snapshots:
       is-arrayish: 0.3.2
 
   slash@3.0.0: {}
+
+  sonner@1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
 

--- a/registry/registry-github.ts
+++ b/registry/registry-github.ts
@@ -3,4 +3,5 @@ export const registry_github_static_info = {
   full_name: "Matheus Figueiredo",
   company: "REAM",
   short_loading: "...",
+  repositories_url: "https://github.com/matheusscode?tab=repositories",
 };

--- a/registry/registry-messages/en.json
+++ b/registry/registry-messages/en.json
@@ -101,7 +101,8 @@
     "gist_cliboard_success": "Copied to clipboard!",
     "gist_cliboard_error": "Error copying text!",
     "gist_cliboard_label_copy": "Copy",
-    "gist_cliboard_label_copied": "Copied!"
+    "gist_cliboard_label_copied": "Copied!",
+    "see_more": "See more!"
   },
   "navigation": {
     "home": "Home",

--- a/registry/registry-messages/en.json
+++ b/registry/registry-messages/en.json
@@ -97,7 +97,11 @@
     "repositories_description": "Check out my GitHub projects and explore the repositories I'm working on.",
     "gist_description": "Check out my custom VSCode settings, optimized for productivity and development with a focus on performance and usability.",
     "repositories_caption": "My repositories ❤️",
-    "gist_caption": "My Visual Studio Code Config ❤️"
+    "gist_caption": "My Visual Studio Code Config ❤️",
+    "gist_cliboard_success": "Copied to clipboard!",
+    "gist_cliboard_error": "Error copying text!",
+    "gist_cliboard_label_copy": "Copy",
+    "gist_cliboard_label_copied": "Copied!"
   },
   "navigation": {
     "home": "Home",

--- a/registry/registry-messages/pt.json
+++ b/registry/registry-messages/pt.json
@@ -97,7 +97,11 @@
     "repositories_description": "Confira meus projetos do GitHub e explore os repositórios em que estou trabalhando.",
     "gist_description": "Confira as minhas configurações personalizadas do VSCode, otimizadas para produtividade e desenvolvimento com foco em performance e usabilidade.",
     "repositories_caption": "Meus repositórios ❤️",
-    "gist_caption": "Minha configuração do Visual Studi Cocde ❤️"
+    "gist_caption": "Minha configuração do Visual Studi Cocde ❤️",
+    "gist_cliboard_success": "Copiado para aréa de transferência",
+    "gist_cliboard_error": "Ocorreu um error ao copiar!",
+    "gist_cliboard_label_copy": "Copiar",
+    "gist_cliboard_label_copied": "Copiado!"
   },
   "navigation": {
     "home": "Início",

--- a/registry/registry-messages/pt.json
+++ b/registry/registry-messages/pt.json
@@ -101,7 +101,8 @@
     "gist_cliboard_success": "Copiado para aréa de transferência",
     "gist_cliboard_error": "Ocorreu um error ao copiar!",
     "gist_cliboard_label_copy": "Copiar",
-    "gist_cliboard_label_copied": "Copiado!"
+    "gist_cliboard_label_copied": "Copiado!",
+    "see_more": "Veja mais!"
   },
   "navigation": {
     "home": "Início",

--- a/ui/projects/github-gist-json.tsx
+++ b/ui/projects/github-gist-json.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import { Button } from "@/packages/components/ui/button";
 import { cn } from "@/packages/utils/cn";
 import { formatJSON } from "@/packages/utils/json";
-import { HTMLAttributes } from "react";
+import { useTranslations } from "next-intl";
+import { HTMLAttributes, useState } from "react";
+import { toast } from "sonner";
 
 export interface GithubGistJSONProps extends HTMLAttributes<HTMLPreElement> {
   schema: Readonly<string>;
@@ -12,7 +16,25 @@ export const GithubGistJSON = ({
   className,
   ...props
 }: GithubGistJSONProps) => {
+  const [hasCopied, setHasCopied] = useState<boolean>(false);
+  const t = useTranslations("projects");
   const formattedJSON = formatJSON(schema);
+
+  const onCopy = () => {
+    navigator.clipboard
+      .writeText(formattedJSON)
+      .then(() => {
+        toast(t("gist_cliboard_success"));
+        setHasCopied(true);
+        setTimeout(() => {
+          setHasCopied(false);
+        }, 3000);
+      })
+      .catch((err) => {
+        setHasCopied(false);
+        toast(`${t("gist_cliboard_error")}: ${err}`);
+      });
+  };
 
   return (
     <div className="mt-3.5 w-full gap-2 rounded-md border border-input shadow-md">
@@ -23,8 +45,11 @@ export const GithubGistJSON = ({
           variant="outline"
           size="sm"
           className="h-6"
+          onClick={onCopy}
         >
-          Copy
+          {hasCopied
+            ? t("gist_cliboard_label_copied")
+            : t("gist_cliboard_label_copy")}
         </Button>
       </div>
       <div className="px-3 py-2">

--- a/ui/projects/github-profile-details.tsx
+++ b/ui/projects/github-profile-details.tsx
@@ -14,7 +14,7 @@ export interface GithubProfileDetailsProps {
 export const GithubProfileDetails = ({ user }: GithubProfileDetailsProps) => {
   return (
     <div className="relative flex h-32 items-center rounded-md border border-input bg-gradient-to-br from-stone-50/50 to-gray-300/50 p-2 shadow-sm transition-all dark:from-transparent dark:to-zinc-900">
-      <div className="absolute -bottom-11 left-8 flex items-center gap-2">
+      <div className="absolute -bottom-11 left-4 flex items-center gap-2 laptop:left-8">
         <div className="relative">
           <Avatar className="min-h-24 min-w-24">
             <AvatarImage
@@ -42,9 +42,15 @@ export const GithubProfileDetails = ({ user }: GithubProfileDetailsProps) => {
             &quot;{user?.bio || registry_github_static_info.short_loading}
             .&quot;
           </em>
+          <span className="block text-sm text-muted-foreground laptop:hidden">
+            Actual Company:{" "}
+            <span className="text-primary">
+              {user?.company || registry_github_static_info.short_loading}
+            </span>
+          </span>
         </div>
       </div>
-      <div className="absolute bottom-2 right-8">
+      <div className="absolute bottom-2 right-8 hidden laptop:block">
         <span className="text-sm text-muted-foreground">
           Actual Company:{" "}
           <span className="text-primary">


### PR DESCRIPTION
# Portfolio Update: External GitHub Link & VSCode Config Copy Feature

This PR adds two new features to the portfolio: 
1. An external link that redirects users to my GitHub repositories page.
2. A new functionality that allows users to view and copy my VSCode settings, rendered through a Gist.

## Features

- [x] **External GitHub Link**: A button or link that directs users to my GitHub repositories in a new tab.
- [x] **VSCode Settings in Gist**: Render my VSCode configuration in a `pre` tag on the page using a GitHub Gist.
- [x] **Copy to Clipboard**: Implement a "Copy" button that allows users to copy the VSCode settings directly from the Gist.

## How it works

- The external link redirects to the GitHub repository page in a new browser tab, ensuring the user remains on the portfolio.
- The VSCode configuration is fetched from a Gist and rendered in a `pre` tag for syntax highlighting and readability.
- A "Copy to Clipboard" button makes it easy for users to copy the configuration file.

